### PR TITLE
Removing restrictions requiring vertex and edge properties to have a …

### DIFF
--- a/src/Stardust.Paradox.Data/CodeGeneration/CodeGenerator.cs
+++ b/src/Stardust.Paradox.Data/CodeGeneration/CodeGenerator.cs
@@ -74,7 +74,7 @@ namespace Stardust.Paradox.Data.CodeGeneration
                     AssemblyBuilderAccess.Run);
             if (_moduleBuilder == null)
                 _moduleBuilder = _builder.DefineDynamicModule("Data.Contracts.Implementations");
-            var typeBuilder = _moduleBuilder.DefineType("Data.Contracts.Implementations.Edges" + entity.Name.Remove(0, 1),
+            var typeBuilder = _moduleBuilder.DefineType("Data.Contracts.Implementations.Edges." + entity.Name.Remove(0, 1),
                 TypeAttributes.Public | TypeAttributes.Class,
                baseType,
                 new[] { dataContract }
@@ -107,7 +107,7 @@ namespace Stardust.Paradox.Data.CodeGeneration
                 //    if (eager != null)
                 //        eagerProperties.Add(prop.Name);
                 //}
-                else if (prop.SetMethod != null)
+                else
                     AddValueProperty(typeBuilder, prop,baseType);
             }
             if (eagerProperties.ContainsElements())
@@ -125,7 +125,7 @@ namespace Stardust.Paradox.Data.CodeGeneration
                     AssemblyBuilderAccess.Run);
             if (_moduleBuilder == null)
                 _moduleBuilder = _builder.DefineDynamicModule("Data.Contracts.Implementations");
-            var typeBuilder = _moduleBuilder.DefineType("Data.Contracts.Implementations.Vertices" + entity.Name.Remove(0, 1),
+            var typeBuilder = _moduleBuilder.DefineType("Data.Contracts.Implementations.Vertices." + entity.Name.Remove(0, 1),
                 TypeAttributes.Public | TypeAttributes.Class,
                 baseType,
                 new[] { dataContract }
@@ -158,7 +158,7 @@ namespace Stardust.Paradox.Data.CodeGeneration
                     if (eager != null)
                         eagerProperties.Add(prop.Name);
                 }
-                else if (prop.SetMethod != null)
+                else
                     AddValueProperty(typeBuilder, prop,baseType);
             }
             if (eagerProperties.ContainsElements())


### PR DESCRIPTION
Removing restrictions requiring vertex and edge properties to have a setter + updating generated type names

### Motivation
**Removing restrictions requiring vertex and edge properties to have a setter**

- removing the restriction will allow creating immutable records. 
Example: I have built a DDD framework on top of Stardust.Paradox which allows to create immutable records and is setting initial values through reflection

- Current restriction can be workarounded by using C# 8 default interface members so it makes the restriction useless
Example:
```csharp
public interface ITest {
    string Id { get; }
    string Name { get; set; }
    string SomeReadonlyProp {
        get { throw new NotImplementedException(); }
        set {}
    }
}
```

**updating generated type names**
`Data.Contracts.Implementations.Vertices.SomeClass` looks nicer than `Data.Contracts.Implementations.VerticesSomeClass`