### PR TITLE
Added Enum Support

### DIFF
--- a/src/Stardust.Paradox.Data/GraphContextBase.cs
+++ b/src/Stardust.Paradox.Data/GraphContextBase.cs
@@ -465,6 +465,8 @@ namespace Stardust.Paradox.Data
                     action.Invoke(item, value == null ? 0 : int.Parse(value?.ToString()));
                 else if (prop.PropertyType == typeof(int?))
                     action.Invoke(item, value == null ? (int?)null : int.Parse(value?.ToString()));
+                else if (prop.PropertyType.IsEnum)
+                    action.Invoke(item, value == null ? default : Enum.Parse(prop.PropertyType, (string)value));
                 else
                     action.Invoke(item, value);
             }

--- a/src/Stardust.Paradox.Data/Internals/Update.cs
+++ b/src/Stardust.Paradox.Data/Internals/Update.cs
@@ -47,6 +47,11 @@ namespace Stardust.Paradox.Data.Internals
 					return yn.ToString(CultureInfo.InvariantCulture).ToLower();
 				case IInlineCollection i:
 					return $"'{i.ToTransferData()}'";
+				case Enum enm:
+					// EscapeGremlinString shouldn't be necessary but just to be sure.
+					var r2 = $"'{enm.ToString().EscapeGremlinString()}'";
+					if (r2 == "'''") return "''";
+					return r2;
 			}
 			throw new ArgumentException("Unknown type", nameof(value));
 		}


### PR DESCRIPTION
Added Enum Support by converting the Enum to String and converting back using Enum.Parse(). null behavior is default of the enum (Which is the first item).
The reason for choosing string not int or long is to make the graph readable from other sources.
As long as the data is entered using Stardust.Paradox, it should be readable.
