### PR TITLE
Enhancements

### DIFF
--- a/src/Stardust.Paradox.Data.Annotations/IEdgeCollection.cs
+++ b/src/Stardust.Paradox.Data.Annotations/IEdgeCollection.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Stardust.Paradox.Data.Annotations
@@ -10,32 +12,37 @@ namespace Stardust.Paradox.Data.Annotations
 
 
     public interface IEdgeCollection
-	{
-		Task LoadAsync();
+    {
+        Task LoadAsync();
 
-		Task SaveChangesAsync();
-	}
-	public interface IEdgeCollection<TTout> : IEdgeCollection, ICollection<IEdge<TTout>>, ICollection<TTout>,IEdgeNavigation<TTout> where TTout : IVertex
-	{
-		Task<IEnumerable<TTout>> ToVerticesAsync();
-		Task<IEnumerable<TTout>> ToVerticesAsync(Expression<Func<TTout, object>> filterSelector, object value);
-		Task LoadAsync(Expression<Func<TTout, object>> filterSelector, object value);
+        Task SaveChangesAsync();
+    }
+    public interface IEdgeCollection<TTout> : IEdgeCollection, ICollection<IEdge<TTout>>, ICollection<TTout>, IEdgeNavigation<TTout> where TTout : IVertex
+    {
+        Task<IEnumerable<TTout>> ToVerticesAsync();
+        Task<IEnumerable<TTout>> ToVerticesAsync([Optional] Expression<Func<TTout, object>> filterSelector, [Optional] object value, 
+                                                 [Optional] Expression<Func<TTout, object>> orderSelector,  [Optional]bool isDesc,
+                                                 [Optional] int pageNumber, [Optional] int pageSize);
 
-		Task<IEnumerable<IEdge<TTout>>> ToEdgesAsync();
-		void Add(TTout vertex, IDictionary<string, object> edgeProperties);
-		void AddDual(TTout vertex);
+        Task LoadAsync(Expression<Func<TTout, object>> filterSelector = null, object value = null,
+                       Expression<Func<TTout, object>> orderSelector = null, bool isDesc = false,
+                       int pageNumber = 0, int pageSize = 0);
+
+        Task<IEnumerable<IEdge<TTout>>> ToEdgesAsync();
+        void Add(TTout vertex, IDictionary<string, object> edgeProperties);
+        void AddDual(TTout vertex);
 
 
-	}
+    }
 
-	public interface IEdgeCollection<TIn, TOut> : IEdgeCollection, ICollection<IEdge<TIn, TOut>> where TIn : IVertex where TOut : IVertex
-	{
-		Task<IEnumerable<TIn>> InVerticesAsync();
+    public interface IEdgeCollection<TIn, TOut> : IEdgeCollection, ICollection<IEdge<TIn, TOut>> where TIn : IVertex where TOut : IVertex
+    {
+        Task<IEnumerable<TIn>> InVerticesAsync();
 
-		Task<IEnumerable<TOut>> OutVerticesAsync();
+        Task<IEnumerable<TOut>> OutVerticesAsync();
 
-		Task<IEnumerable<IEdge<TIn, TOut>>> AsEnumerableAsync();
-	}
+        Task<IEnumerable<IEdge<TIn, TOut>>> AsEnumerableAsync();
+    }
 
-	
+
 }

--- a/src/Stardust.Paradox.Data.Annotations/Stardust.Paradox.Data.Annotations.csproj
+++ b/src/Stardust.Paradox.Data.Annotations/Stardust.Paradox.Data.Annotations.csproj
@@ -24,8 +24,8 @@ Added</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Stardust.Paradox.Data.CosmosDbTests/Stardust.Paradox.Data.CosmosDbTests.csproj
+++ b/src/Stardust.Paradox.Data.CosmosDbTests/Stardust.Paradox.Data.CosmosDbTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -8,13 +8,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Graphs" Version="0.3.1-preview" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20171031-01" />
-    <PackageReference Include="Stardust.Nucleus" Version="5.0.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Stardust.Nucleus" Version="5.0.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
   </ItemGroup>
 

--- a/src/Stardust.Paradox.Data.Providers.CosmosDb/Stardust.Paradox.Data.Providers.CosmosDb.csproj
+++ b/src/Stardust.Paradox.Data.Providers.CosmosDb/Stardust.Paradox.Data.Providers.CosmosDb.csproj
@@ -21,10 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="2.9.2" />
     <PackageReference Include="Microsoft.Azure.Graphs" Version="0.3.1-preview" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stardust.Paradox.Data.Providers.Gremlin/Stardust.Paradox.Data.Providers.Gremlin.csproj
+++ b/src/Stardust.Paradox.Data.Providers.Gremlin/Stardust.Paradox.Data.Providers.Gremlin.csproj
@@ -23,7 +23,7 @@ Added retry on connection issues</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gremlin.Net" Version="3.4.1" />
+    <PackageReference Include="Gremlin.Net" Version="3.4.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stardust.Paradox.Data.UnitTests/Stardust.Paradox.Data.UnitTests.csproj
+++ b/src/Stardust.Paradox.Data.UnitTests/Stardust.Paradox.Data.UnitTests.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
   </ItemGroup>
 

--- a/src/Stardust.Paradox.Data/Extensions/MemberSelectorHelper.cs
+++ b/src/Stardust.Paradox.Data/Extensions/MemberSelectorHelper.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq.Expressions;
+
+namespace Stardust.Paradox.Data.Extensions
+{
+    internal static class MemberSelectorExtensions
+    {
+        internal static MemberExpression ExtractMemberExpression(this Expression expression)
+        {
+            if (expression.NodeType == ExpressionType.MemberAccess)
+            {
+                return ((MemberExpression)expression);
+            }
+
+            if (expression.NodeType == ExpressionType.Convert)
+            {
+                var operand = ((UnaryExpression)expression).Operand;
+                return ExtractMemberExpression(operand);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Stardust.Paradox.Data/Stardust.Paradox.Data.csproj
+++ b/src/Stardust.Paradox.Data/Stardust.Paradox.Data.csproj
@@ -32,20 +32,21 @@ Performance fixes</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="SecurityCodeScan" Version="3.3.0">
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="SecurityCodeScan" Version="3.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Stardust.Particles" Version="5.0.1" />
+    <PackageReference Include="Stardust.Particles" Version="5.0.2" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Added paging for ToVerticesAsync()
* Added Sorting for ToVerticesAsync()
* Updated Nuget Packages

Due to a bug in Microsoft.Azure.Graphs Nuget, sorting is not working on Long properties (Or their derrivatives, like DateTIme.Ticks) when using CosmosDbLanguageConnector and will result in an exception.